### PR TITLE
Readme and Lecture 1: Fix typos, structure improvements and small clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,5 @@ data/
 
 1. Create [Kaggle](https://www.kaggle.com/) account
 2. Proceed [with Installation & Authentication](https://www.kaggle.com/docs/api#getting-started-installation-&-authentication)
-3. Download dataset with API command 
+3. Don't forget to join a competition and accept its rules on a Kaggle website.
+4. Download dataset with API command 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ conda env create -f environment.yaml
 
 # Start Jupyter
 
+Activate your newly created environment
+```bash
+conda activate iasa_nlp_env
+```
+
 You may use any port 
 ```bash
 jupyter lab --port 7766

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jupyter lab --port 7766
 - For most of lectures you will need datasets from Kaggle. [Prepare in advance](#how-to-use-kaggle-datasets)
     - CommonLit - Evaluate Student Summaries dataset API command: `kaggle competitions download -c commonlit-evaluate-student-summaries`
     - Natural Language Processing with Disaster Tweets dataset API command: `kaggle competitions download -c nlp-getting-started`
-- We recommend to create `data` folder and put all datasets there. So you might have next structure
+- We recommend to create `data` folder in the course root directory and put all datasets there. So you might have next structure
 
 ```
 data/
@@ -76,6 +76,8 @@ data/
         test.csv
         ...
     ...
+Lecture_1/
+...
 ```
 
 ## How to use Kaggle datasets

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ data/
 
 ## How to use Kaggle datasets
 
-1. Create Kaggle account 
 1. Create [Kaggle](https://www.kaggle.com/) account
 2. Proceed [with Installation & Authentication](https://www.kaggle.com/docs/api#getting-started-installation-&-authentication)
 3. Download dataset with API command 


### PR DESCRIPTION
I made several minor improvements for the Readme.MD and lecture 1 notebook:

- `Readme.MD`:
    - Added info on environment activation before starting Jupyter.
    - Clarified structure of repo with `data/` folder added.
    - Added a note on competition join before dataset downloading.
- `Lecture_1/Formalization_of_Ml_task.ipynb`:
    - Added nltk download needed to work.
    - Clarified and improved several formulations.
    - Switched from XML to LaTEX in formulas (XML wasn't visible in Jupyter and on GitHub).
    - Improved structure a bit.
    - Fixed many typos.
    - Improved punktuation.